### PR TITLE
Allow accessing and setting array values using subscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ def _start():
       cube_insta.set_position(
         UnityEngineVector3.ctor(tmp_x, 0.0, tmp_y)
       )
-      cubes.Set(10 * y_i + x_i, cube_obj)
+      cubes[10 * y_i + x_i] = cube_obj
       x_i = x_i + 1
     y_i = y_i + 1 
 
@@ -133,7 +133,7 @@ def _onMouseDown():
   cube_i = 0
   while cube_i < 10 * 10:
     # Color change randomly
-    cube_renda = UnityEngineRenderer(cubes.Get(cube_i).GetComponent('Renderer'))
+    cube_renda = UnityEngineRenderer(cubes[cube_i].GetComponent('Renderer'))
     cube_renda.get_material().set_color(UnityEngineRandom.ColorHSV())
     cube_i = cube_i + 1 
 

--- a/libs/tables.py
+++ b/libs/tables.py
@@ -85,7 +85,7 @@ class DefFuncTable:
   def get_ret_type(self, func_name: FuncName, arg_types: Tuple[UdonTypeName, ...]) -> UdonTypeName:
     ret_type: UdonTypeName
     if not self.exist_func(func_name, arg_types):
-      raise Exception(f'DefFuncTable.get_ret_type: Fuction {func_name}{arg_types} is not defined. \
+      raise Exception(f'DefFuncTable.get_ret_type: Function {func_name}{arg_types} is not defined. \
 Are the argument types correct?')
     ret_type, _ = self.func_dict[func_name, arg_types]
     return ret_type

--- a/sample/lights_out_main.py
+++ b/sample/lights_out_main.py
@@ -13,10 +13,10 @@ def init_vars()->SystemVoid:
 def flip(arg_x:SystemInt32, arg_y:SystemInt32)->SystemVoid:
   if (0 <= arg_x and arg_x < n_w) and (0 <= arg_y and arg_y < n_h):
     button_id = n_w * arg_y + arg_x
-    if flip_flags.Get(button_id):
-      flip_flags.Set(button_id, False)
+    if flip_flags[button_id]:
+      flip_flags[button_id] = False
     else:
-      flip_flags.Set(button_id, True)
+      flip_flags[button_id] = True
   return
 
 def _start():
@@ -33,7 +33,7 @@ def _start():
         UnityEngineVector3.ctor(tmp_x, 0.0, tmp_y)
       )
       button_id = n_w * y_i + x_i
-      buttons.Set(button_id, button_obj)
+      buttons[button_id] = button_obj
       x_i = x_i + 1
     y_i = y_i + 1 
 
@@ -56,8 +56,8 @@ def _update():
     x_i = 0
     while x_i < n_w:
       button_id = n_h * y_i + x_i
-      button_obj = buttons.Get(button_id)
-      flip_flag = flip_flags.Get(button_id)
+      button_obj = buttons[button_id]
+      flip_flag = flip_flags[button_id]
       button_renda = UnityEngineRenderer(button_obj.GetComponent('Renderer'))
       if button_renda.get_material().get_color().Equals(red_color):
         flip(x_i, y_i)

--- a/sample/rand_cube.py
+++ b/sample/rand_cube.py
@@ -21,7 +21,7 @@ def _start():
       cube_insta.set_position(
         UnityEngineVector3.ctor(tmp_x, 0.0, tmp_y)
       )
-      cubes.Set(10 * y_i + x_i, cube_obj)
+      cubes[10 * y_i + x_i] = cube_obj
       x_i = x_i + 1
     y_i = y_i + 1 
 
@@ -30,6 +30,6 @@ def _onMouseDown():
   cube_i = 0
   while cube_i < 10 * 10:
     # Color change randomly
-    cube_renda = UnityEngineRenderer(cubes.Get(cube_i).GetComponent('Renderer'))
+    cube_renda = UnityEngineRenderer(cubes[cube_i].GetComponent('Renderer'))
     cube_renda.get_material().set_color(UnityEngineRandom.ColorHSV())
     cube_i = cube_i + 1 

--- a/udon_compiler.py
+++ b/udon_compiler.py
@@ -602,7 +602,7 @@ class UdonCompiler:
       self.uasm.assign(cast_var_name, arg_var_name)
       return cast_var_name
     
-    # Call defined fuction
+    # Call defined function
     else:
       return self.uasm.call_def_func(org_func, arg_var_names)
 

--- a/udon_compiler.py
+++ b/udon_compiler.py
@@ -95,12 +95,12 @@ class UdonCompiler:
         names = _global.names
         for name in names:
           self.var_table.global_var_names.append(VarName(name))
-      # Assgin statment
+      # Assign statment
       #  | Assign(expr* targets, expr value)
       elif type(stmt) is ast.Assign:
-        assgin: ast.Assign = cast(ast.Assign, stmt)
+        assign: ast.Assign = cast(ast.Assign, stmt)
         # right expression
-        src_var_name: Optional[VarName] = self.eval_expr(assgin.value)
+        src_var_name: Optional[VarName] = self.eval_expr(assign.value)
         if src_var_name is None:
           raise Exception(f'{stmt.lineno}:{stmt.col_offset} {self.print_ast(stmt)}: There is no value on the right side of the assignment statement.')
         # left expression


### PR DESCRIPTION
# Problem
Currently accessing and setting variables in an array has to be done through the `Get` and `Set` method calls, e.g. `SystemStringArray.Get` and `SystemStringArray.Set`. This is inconvinient and unusual for programmers, and acts as a barrier-of-entry.

# Goals
This merge request adds support for compiling `ast.Subscript` during variable assignment and as a general expression, allowing the use arrays more similar to traditional python and other languages.

# Non-goals
It is outside the scope of this pull request to add support for constructing arrays using `ast.List` syntax, i.e. creating a new array with `array = [1, 2, 3]` syntax. This should be done in a separate pull request.

# Proposed Changes

- Fixes typos "assgin" and "fuction"
- Allows accessing array values with `array[0]`
- Allows assigning array values with `array[0] = 3`
- Updates affected samples to reflect these changes

# Example/Demo
```python
from . udon_classes import *

def _start():
  # Array construction still has to be done with ctor,
  # as this is outside the scope of this pull request.
  movies = SystemStringArray.ctor(3)

  # Old method:   movies.Set(0, "Your Name/Kimi no Na Wa")
  # New method:
  movies[0] = "Your Name/Kimi no Na Wa"
  movies[1] = "Hibike! Euphonium"
  movies[2] = "Koe No Katachi/A Silent Voice"

  # Old method:   UnityEngineDebug.Log(SystemObject(movies.Get(0)))
  # New method:
  UnityEngineDebug.Log(SystemObject(movies[0]))
  UnityEngineDebug.Log(SystemObject(movies[1]))
  UnityEngineDebug.Log(SystemObject(movies[2]))
```