### PR TITLE
Overwrites saved UdonBehaviour's type-name in Uasm

### DIFF
--- a/libs/tables.py
+++ b/libs/tables.py
@@ -60,7 +60,11 @@ class VarTable:
         raise Exception(f'make_data_seg: Global variable {var_name} is not defined.')
       data_str += f'    .export {var_name}\n'
     for (var_name, (type_name, init_value)) in self.var_dict.items():
-      data_str += f'        {var_name}: %{type_name}, {init_value}\n'
+      # There is no class with the name VRCUdonUdonBehaviour, but UdonVM requires it to be named like that anyway.
+      if type_name == "VRCUdonCommonInterfacesIUdonEventReceiver":
+        data_str += f'        {var_name}: %VRCUdonUdonBehaviour, {init_value}\n'
+      else:
+        data_str += f'        {var_name}: %{type_name}, {init_value}\n'
     data_str += f'\n.data_end\n\n'
     return data_str
 


### PR DESCRIPTION
Fixes #2 

Currently it is not possible to correctly assign UdonBehaviour's in the Inspector view in Unity. This is because the variable is being saved with it's correct name, when Unity in reality expects a wrong name.

Ideally the VRChat team should have updated the UdonSDK to properly recognize and handle variable assignments in Unity, but that is unlikely to happen any time soon. This pull-request implements a workaround.

This changes variables from being stored in UAssembly from `VRCUdonCommonInterfacesIUdonEventReceiver` to `VRCUdonUdonBehaviour`. This is done last-step before uasm generation, to not interfere with anything else in the compiler. 