### PR TITLE
Allow udon_compiler.py to work when run from outside of the main directory

### DIFF
--- a/libs/tables.py
+++ b/libs/tables.py
@@ -15,7 +15,7 @@ from libs.udon_types import *
 def resource_path(relative_path: str) -> str:
     if hasattr(sys, '_MEIPASS'):
         return os.path.join(sys._MEIPASS, relative_path) # type: ignore
-    return os.path.join(os.path.abspath("."), relative_path)
+    return os.path.join(os.path.dirname(__file__), "..", relative_path)
 
 class VarTable:
   """


### PR DESCRIPTION
This is a temporary fix using the relative path from the tables.py file